### PR TITLE
Restore independence from Snagit

### DIFF
--- a/Externals/RMSharedPreferences/RMSharedUserDefaults.h
+++ b/Externals/RMSharedPreferences/RMSharedUserDefaults.h
@@ -38,6 +38,11 @@
 - (instancetype)initWithApplicationGroupIdentifier:(NSString *)applicationGroupIdentifier NS_DESIGNATED_INITIALIZER;
 @property (readonly) BOOL wasPreExisting;
 
+/*! Subclasses may override to customize the path to the preferences file by inserting an optional subdirectry into the path.
+ 
+   Snagit uses this to put the preference for each annual release into its own subdirectory.
+*/
+@property (readonly) NSString* optionalSubDirectoryName;
 @end
 
 extern NSString * const RMSharedUserDefaultsDidChangeDefaultNameKey;

--- a/Externals/RMSharedPreferences/RMSharedUserDefaults.m
+++ b/Externals/RMSharedPreferences/RMSharedUserDefaults.m
@@ -28,8 +28,6 @@
 
 #import "NSURL+RMApplicationGroup.h"
 #import "NSObject+RMSubclassSupport.h"
-#import "snagitconstants.h"
-#import <SnagitCommon/SnagitCommon-Swift.h>
 
 NSString * const RMSharedUserDefaultsDidChangeDefaultNameKey = @"RMSharedUserDefaultsDidChangeDefaultNameKey";
 NSString * const RMSharedUserDefaultsDidChangeDefaulValueKey = @"RMSharedUserDefaultsDidChangeDefaulValueKey";
@@ -93,8 +91,13 @@ NSString * const RMSharedUserDefaultsDidChangeDefaulValueKey = @"RMSharedUserDef
 		return nil;
 	}
 	
-   NSString* bundleName = NSApp.gestalt.productBundleName;
-   NSURL *applicationGroupPreferencesLocation = [[applicationGroupLocation URLByAppendingPathComponent:bundleName] URLByAppendingPathComponent:@"Preferences"];
+   NSURL *applicationGroupPreferencesLocation = applicationGroupLocation;
+   NSString* optionalSubdirectoryName = [self optionalSubDirectoryName];
+   if ( optionalSubdirectoryName ) {
+      applicationGroupPreferencesLocation = [applicationGroupPreferencesLocation URLByAppendingPathComponent:optionalSubdirectoryName];
+   }
+   applicationGroupPreferencesLocation = [applicationGroupPreferencesLocation URLByAppendingPathComponent:@"Preferences"];
+   
 	[[NSFileManager defaultManager] createDirectoryAtURL:applicationGroupPreferencesLocation withIntermediateDirectories:YES attributes:nil error:NULL];
 	
 	NSString *userDefaultsDictionaryFileName = applicationGroupIdentifier ? : [NSURL defaultGroupContainerIdentifier];
@@ -136,6 +139,11 @@ NSString * const RMSharedUserDefaultsDidChangeDefaulValueKey = @"RMSharedUserDef
 }
 
 #pragma mark - Accessors
+
+- (NSString*)optionalSubDirectoryName
+{
+   return nil;
+}
 
 - (id)objectForKey:(NSString *)defaultName
 {

--- a/Externals/RMSharedPreferences/RMSharedUserDefaults.m
+++ b/Externals/RMSharedPreferences/RMSharedUserDefaults.m
@@ -29,6 +29,7 @@
 #import "NSURL+RMApplicationGroup.h"
 #import "NSObject+RMSubclassSupport.h"
 #import "snagitconstants.h"
+#import <SnagitCommon/SnagitCommon-Swift.h>
 
 NSString * const RMSharedUserDefaultsDidChangeDefaultNameKey = @"RMSharedUserDefaultsDidChangeDefaultNameKey";
 NSString * const RMSharedUserDefaultsDidChangeDefaulValueKey = @"RMSharedUserDefaultsDidChangeDefaulValueKey";
@@ -92,7 +93,8 @@ NSString * const RMSharedUserDefaultsDidChangeDefaulValueKey = @"RMSharedUserDef
 		return nil;
 	}
 	
-   NSURL *applicationGroupPreferencesLocation = [[applicationGroupLocation URLByAppendingPathComponent:kSnagitBundleName] URLByAppendingPathComponent:@"Preferences"];
+   NSString* bundleName = NSApp.gestalt.productBundleName;
+   NSURL *applicationGroupPreferencesLocation = [[applicationGroupLocation URLByAppendingPathComponent:bundleName] URLByAppendingPathComponent:@"Preferences"];
 	[[NSFileManager defaultManager] createDirectoryAtURL:applicationGroupPreferencesLocation withIntermediateDirectories:YES attributes:nil error:NULL];
 	
 	NSString *userDefaultsDictionaryFileName = applicationGroupIdentifier ? : [NSURL defaultGroupContainerIdentifier];


### PR DESCRIPTION
Keep RMSharedPreferences independent of Snagit

#### Developer Notes
RMSharedPreferences had become entangled with Snagit code.

##### First commit: "gestalt.productBundleName instead of kSnagitBundleName"
In this commit I did a simple replacement of kSnagitBundleName with gestalt.productBundleName

##### Second commit: "Remove dependence on Snagit "
In this commit, I added a method to RMSharedUserDefaults that we now override in Snagit allowing the RMSharedPreferences code to remain independent of Snagit.